### PR TITLE
Header alignment default should be column alignment

### DIFF
--- a/lib/PDF/Table.pm
+++ b/lib/PDF/Table.pm
@@ -381,7 +381,7 @@ sub table
         $header_props->{'font_color'    } = $header_props->{'font_color'    } || '#000066';
         $header_props->{'font_size'     } = $header_props->{'font_size'     } || $fnt_size + 2;
         $header_props->{'bg_color'      } = $header_props->{'bg_color'      } || '#FFFFAA';
-        $header_props->{'justify'       } = $header_props->{'justify'       } || 'left';
+        $header_props->{'justify'       } = $header_props->{'justify'       };
     }
 
     my $header_row  = undef;
@@ -1199,7 +1199,7 @@ Don't forget that your function must return a page object created with PDF::API2
 
 =head4 Header Row Properties
 
-If the 'header_props' parameter is used, it should be a hashref. Passing an empty HASH will triger a header row initialised with Default values.
+If the 'header_props' parameter is used, it should be a hashref. Passing an empty HASH will trigger a header row initialised with Default values.
 There is no 'data' variable for the content, because the module asumes that first table row will become the header row. It will copy this row and put it on every new page if 'repeat' param is set.
 
 =over
@@ -1229,10 +1229,10 @@ B<Default:> #FFFFAA
 B<Value:> 0,1   1-Yes/True, 0-No/False 
 B<Default:> 0
 
-=item B<justify> - Alignment of text in the header row
+=item B<justify> - Alignment of text in the header row.
 
 B<Value:> One of 'left', 'right', 'center'
-B<Default:> 'left'
+B<Default:> Same as column alignment (or 'left' if undefined)
 
     my $hdr_props = 
     {

--- a/t/Basics.t
+++ b/t/Basics.t
@@ -1,4 +1,4 @@
-use Test::More tests => 5;
+use Test::More tests => 6;
 use strict;
 use warnings;
 
@@ -54,4 +54,44 @@ ok(
     'default break long words on every 20th character'
 ) or note explain $pdf;
 
+#
+# Test header alignment if unspecified (should default to column alignment
+# if unspecified)
+# 
+$pdf  = PDF::API2->new();
+$page = $pdf->page();
+$tab  = PDF::Table->new($pdf,$page);
+
+@data = ( [ 'head1', 'head2', 'head3'], [ 'foo', 'bar', 'baz' ], );
+
+# Match column properties to default header properties
+my $col_props = [
+    { font_color => '#000066', font_size => 14, background_color => '#FFFFAA', justify => 'left' },
+    { font_color => '#000066', font_size => 14, background_color => '#FFFFAA', justify => 'center' },
+    { font_color => '#000066', font_size => 14, background_color => '#FFFFAA', justify => 'right' },
+];
+%opts = (
+    %TestData::required,
+    column_props => $col_props,
+);
+$tab->table( $pdf, $page, \@data, %opts );
+my @pdf_no_header_props = $pdf->getall;
+
+my $pdf2  = PDF::API2->new();
+my $page2 = $pdf2->page();
+my $tab2  = PDF::Table->new($pdf2,$page2);
+
+@data = ( [ 'head1', 'head2', 'head3'], [ 'foo', 'bar', 'baz' ], );
+%opts = (
+    %TestData::required,
+    header_props => {
+       repeat => 1,
+    },
+    column_props => $col_props,
+);
+$tab2->table( $pdf2, $page2, \@data, %opts );
+ok(
+    $pdf2->match( \@pdf_no_header_props ),
+    'Header alignment does not match column alignment if unspecified'
+) or note explain $pdf2;
 


### PR DESCRIPTION
If 'justify' is not included in header_props argument, the default
alignment should match the given column alignment. If the column is
left-justified, the header will be left-justified. If the column is
centered, the header will be centered. If no column alignment is
specified, the default (for both) is left-justified.