### PR TITLE
Fixed new_page_func valid setting

### DIFF
--- a/lib/PDF/Table.pm
+++ b/lib/PDF/Table.pm
@@ -313,7 +313,7 @@ sub table
         background_color_odd  => 1,
         background_color_even => 1,
         row_height            => 1,
-        new_page              => 1,
+        new_page_func         => 1,
         header_props          => 1,
         column_props          => 1,
         cell_props            => 1,


### PR DESCRIPTION
In e3ec184 the parameters to table() are validated. The new_page
setting key should be new_page_func.