### PR TITLE
Fix crashing bug when a page overflow happens when rendering the header of a table

### DIFF
--- a/lib/PDF/Table.pm
+++ b/lib/PDF/Table.pm
@@ -812,8 +812,9 @@ sub table {
                 unshift @$rows_height, $header_min_rh;
 
                 $first_row = 1; # Means YES
-                # Roll back the row_idx because a new header row added
-                $row_idx--; 
+                # Roll back the row_idx because a new header row added, unless it was the
+                # header itself that overflowed.
+                $row_idx-- if $row_idx > 0;
             }
              
         }

--- a/t/PDF-Table.t
+++ b/t/PDF-Table.t
@@ -157,4 +157,28 @@ ok($pdf->match(
       [['text', 'abcdefghijklm nopqrstuvwxyz']],
 ), 'break long words on max_word_length');
 
+$pdf = PDF::API2->new;
+$page = $pdf->page;
+@data = (
+      [ 'Name', 'Description', 'Intent', 'Flavour', 'Colour',
+        'Intense philosophical discussion on how much certainty'
+        . ' we can put on the truth of anything',
+        'Price',
+      ],
+      [ 'Chocolate', 'Brown and sugary', 'Be tasty', 'Tasty', 'Brown, I said',
+        'Who cares?',
+        '9.99' ],
+      [ 'Angst', 'Uncomfortable', 'Annoy you', 'None', 'Also none',
+        'Ironically, we can probably be sure that this exists',
+        'Who would *buy* this?'
+      ],
+);
+$tab->table(
+      $pdf, $page, [@data], @required,
+      header_props => { repeat => 1 },
+      w => 400,
+      font_size => 10,
+      start_y => 100,
+);
+
 1;

--- a/t/PDF-Table.t
+++ b/t/PDF-Table.t
@@ -60,6 +60,7 @@ my ($pdf, $page, $tab, @data, @required);
       next_y => 700,
       start_h => 40,
       next_h => 500,
+      font_size => 12,
 );
 
 $pdf = PDF::API2->new;
@@ -74,7 +75,6 @@ $tab = PDF::Table->new($pdf, $page);
 $tab->table($pdf, $page, [@data], @required,
       border => 1,
       border_color => 'black',
-      font_size => 12,
       background_color => 'gray',
       column_props => [
             {}, { background_color => 'red' }, {},
@@ -106,7 +106,6 @@ $page = $pdf->page;
 $tab->table($pdf, $page, [@data], @required,
       border => 0,
       border_color => 'black',
-      font_size => 12,
       column_props => [
             {}, { justify => 'center' }, { justify => 'center' },
       ],
@@ -137,7 +136,6 @@ $pdf = PDF::API2->new;
 $page = $pdf->page;
 $tab->table($pdf, $page, [@data], @required,
       border => 0,
-      font_size => 12,
       max_word_length => 13,
       cell_props => [
             [],


### PR DESCRIPTION
This bug bit us in production just now: if the *header* of a table is too large to render on the page, overflow behaviour is triggered, which decides that it needs to go back to the previous row (I think so it can display a header instead and then go back to the current row). But if it was the header that wrapped, $idx_row will end up negative, which isn't a valid array index.

I appreciate that the contribution guide says to raise an issue instead of a PR, but it was as easy to add a test (that promptly crashed) and then fix it, than to cut and paste basically the same code into an issue.

Ideally the proper solution would be not to even *try* to display a header for the first time if it's going to wrap, but that feels like a more complicated widow-and-orphan fix.